### PR TITLE
MySQLの設定の変更

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -13,8 +13,8 @@ default: &default
   adapter: mysql2
   encoding: utf8mb4
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  username: <%= ENV["DB_USERNAME"] %>
-  password: <%= ENV["DB_PASSWORD"] %>
+  username: root
+  password:
   socket: /tmp/mysql.sock
 
 development:

--- a/config/initializers/mysql.rb
+++ b/config/initializers/mysql.rb
@@ -1,0 +1,9 @@
+require 'active_record/connection_adapters/abstract_mysql_adapter'
+
+module ActiveRecord
+  module ConnectionAdapters
+    class AbstractMysqlAdapter
+      NATIVE_DATABASE_TYPES[:string] = { :name => "varchar", :limit => 191 }
+    end
+  end
+end


### PR DESCRIPTION
### 実現したいこと
- mysqlを起動する時にsudoコマンドを打たなくても起動ができるようにしたい

### 完了の定義
- [ ] ターミナルから`mysql -u root -p`でDBにアクセスできれば完了